### PR TITLE
fix(client-github): read private-repo file bodies via authed Contents API

### DIFF
--- a/packages/client-github/src/github/github-api.live.spec.ts
+++ b/packages/client-github/src/github/github-api.live.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { createGithubApi } from './github-api'
+
+// ---------------------------------------------------------------------------
+// Live regression test for the private-repo file-body-read bug.
+//
+// Before the fix, `getFileText` always hit unauthenticated
+// raw.githubusercontent.com, which 404s on private repos even when a valid
+// token is configured — silently breaking reads for private vaults (the
+// entire point of OpenVaultDB). This test hits a real private GitHub repo
+// (trakhimenok/ovdb-test-vault, branch `poc/live-contact`) to prove the
+// authenticated Contents API path actually works end-to-end.
+//
+// Skipped automatically when no token is available, so it never fails CI /
+// other contributors' local runs. To run it locally:
+//   INGITDB_TEST_GITHUB_TOKEN=$(gh auth token) pnpm -C packages/client-github test:run
+// ---------------------------------------------------------------------------
+
+const token = process.env.INGITDB_TEST_GITHUB_TOKEN
+
+describe.skipIf(!token)('createGithubApi (live, private repo)', () => {
+  it('reads a file body from a private repo via the authenticated Contents API', async () => {
+    const api = createGithubApi(token)
+    const result = await api.getFileText(
+      'trakhimenok/ovdb-test-vault',
+      'contacts/$records/contact-jane-doe.json',
+      'poc/live-contact'
+    )
+    const record = JSON.parse(result.decodedContent) as { email?: string; firstName?: string; lastName?: string }
+    expect(record.firstName).toBe('Jane')
+    expect(record.lastName).toBe('Doe')
+    expect(record.email).toBe('jane@example.com')
+    expect(result.sha).toBeTruthy()
+  })
+})

--- a/packages/client-github/src/github/github-api.spec.ts
+++ b/packages/client-github/src/github/github-api.spec.ts
@@ -189,6 +189,54 @@ describe('createGithubApi', () => {
     )
   })
 
+  // ── getFileText (private repo / authenticated) ─────────────────────────
+  it('getFileText uses authenticated Contents API when a token is configured', async () => {
+    const base64 = btoa(unescape(encodeURIComponent('yaml: content')))
+    mocks.httpMock.get.mockResolvedValueOnce({ data: { content: base64, encoding: 'base64', sha: 'filesha' } })
+    const api = createGithubApi('ghp_test')
+    const result = await api.getFileText('o/r', 'path/file.yaml')
+    expect(mocks.httpMock.get).toHaveBeenCalledWith('/repos/o/r/contents/path/file.yaml', {
+      params: { ref: 'main' }
+    })
+    expect(mocks.rawHttpMock.get).not.toHaveBeenCalled()
+    expect(result).toEqual({ decodedContent: 'yaml: content', sha: 'filesha' })
+  })
+
+  it('getFileText (authed) passes the specified branch as ref', async () => {
+    const base64 = btoa(unescape(encodeURIComponent('data')))
+    mocks.httpMock.get.mockResolvedValueOnce({ data: { content: base64, sha: 's1' } })
+    const api = createGithubApi('ghp_test')
+    await api.getFileText('o/r', 'f.yaml', 'dev')
+    expect(mocks.httpMock.get).toHaveBeenCalledWith('/repos/o/r/contents/f.yaml', {
+      params: { ref: 'dev' }
+    })
+  })
+
+  it('getFileText (authed) decodes GitHub-style line-wrapped base64 content', async () => {
+    const raw = btoa(unescape(encodeURIComponent('line1\nline2\n')))
+    const wrapped = raw.match(/.{1,4}/g)!.join('\n') // simulate GitHub's ~60-char wrapping
+    mocks.httpMock.get.mockResolvedValueOnce({ data: { content: wrapped, sha: 's2' } })
+    const api = createGithubApi('ghp_test')
+    const result = await api.getFileText('o/r', 'f.yaml')
+    expect(result.decodedContent).toBe('line1\nline2\n')
+  })
+
+  it('getFileText (authed) throws when the path is a directory (array response)', async () => {
+    mocks.httpMock.get.mockResolvedValueOnce({ data: [{ name: 'a.yaml' }] })
+    const api = createGithubApi('ghp_test')
+    await expect(api.getFileText('o/r', 'somedir')).rejects.toThrow(
+      'Expected a file at "somedir", got a directory or content-less response'
+    )
+  })
+
+  it('getFileText (authed) throws when content field is missing', async () => {
+    mocks.httpMock.get.mockResolvedValueOnce({ data: { sha: 's3' } })
+    const api = createGithubApi('ghp_test')
+    await expect(api.getFileText('o/r', 'f.yaml')).rejects.toThrow(
+      'Expected a file at "f.yaml", got a directory or content-less response'
+    )
+  })
+
   // ── putFile ─────────────────────────────────────────────────────────────
   it('putFile sends PUT with base64 content', async () => {
     mocks.httpMock.put.mockResolvedValueOnce({ data: { content: { sha: 'abc' } } })

--- a/packages/client-github/src/github/github-api.ts
+++ b/packages/client-github/src/github/github-api.ts
@@ -27,6 +27,12 @@ const parseRepo = (repo: string): { owner: string; name: string } => {
   return { owner, name }
 }
 
+/** Decodes a base64 string (as returned by the GitHub Contents API, which
+ * line-wraps at 60 chars) back into a UTF-8 string. Mirrors the encoding
+ * used by `putFile` (`btoa(unescape(encodeURIComponent(content)))`). */
+const decodeBase64Content = (base64: string): string =>
+  decodeURIComponent(escape(atob(base64.replace(/\s/g, ''))))
+
 function updateRateLimit(headers: AxiosResponseHeaders | RawAxiosResponseHeaders, rl: RateLimit): void {
   rl.limit = Number(headers['x-ratelimit-limit'] || NaN) || null
   rl.remaining = Number(headers['x-ratelimit-remaining'] || NaN) || null
@@ -109,6 +115,23 @@ export function createGithubApi(token?: string): GithubApi {
     async getFileText(repo: string, path: string, branch?: string): Promise<FileTextResult> {
       const { owner, name } = parseRepo(repo)
       const branchRef = branch || 'main'
+
+      // Private repos 404 against unauthenticated raw.githubusercontent.com, so
+      // when a token is configured, read the file body via the authenticated
+      // Contents API instead (works for both public and private repos). The
+      // Contents API caps file size at ~1MB; raw has no such limit, so we keep
+      // using raw for the no-token / public-repo case (it's also faster/cheaper).
+      if (token) {
+        const { data } = await http.get<{ content?: string; encoding?: string; sha?: string }>(
+          `/repos/${owner}/${name}/contents/${path}`,
+          { params: { ref: branchRef } }
+        )
+        if (Array.isArray(data) || typeof data.content !== 'string') {
+          throw new Error(`Expected a file at "${path}", got a directory or content-less response`)
+        }
+        return { decodedContent: decodeBase64Content(data.content), sha: data.sha }
+      }
+
       const downloadUrl = `https://raw.githubusercontent.com/${owner}/${name}/${branchRef}/${path}`
       const { data } = await rawHttp.get<string>(downloadUrl)
       return { decodedContent: data }


### PR DESCRIPTION
## The bug

`@ingitdb/client-github`'s directory listing already uses the **authenticated** GitHub Contents API and works fine on private repos, but `getFileText` (file-body read) fetched from **unauthenticated `raw.githubusercontent.com`**, which **404s on private repos**. Effect: the client can discover a record's id but fails to read its content, so schema/records silently fall back to empty — a private vault appears empty. This breaks the entire OpenVaultDB "your data in your private repo" premise, since vaults must be private.

## The fix

In `packages/client-github/src/github/github-api.ts`, `getFileText`:
- **When a token is configured**: reads the file body via the authenticated `GET /repos/{owner}/{repo}/contents/{path}?ref={branch}` endpoint and base64-decodes the response `content` field (mirrors the existing `btoa(unescape(encodeURIComponent(...)))` encoding used by `putFile`, handling GitHub's line-wrapped base64).
- **When no token is configured**: unchanged — still reads from unauthenticated `raw.githubusercontent.com` (public repos only; faster and cheaper, no auth needed).

The selection is based purely on whether `token` was passed to `createGithubApi(token)`, matching the existing pattern already used by the request interceptor for the Contents/Git APIs. No rewrite of the client — this is localized to the one function, using the `GithubApi` abstraction the package already has.

## ~1MB caveat

The Contents API caps file size at ~1MB; `raw.githubusercontent.com` has no such limit. Fine for vault JSON records (schema/record files), but worth flagging if larger blobs are ever stored in a private vault — a follow-up (e.g. falling back to the Git Blobs API for big files) may be needed later.

## Tests

- Existing 182 tests still green.
- Added 5 focused unit tests in `github-api.spec.ts` covering: authed Contents API is used when a token is present (with correct endpoint + `ref` param), base64 decoding (including GitHub's line-wrapped base64), and error handling when the path resolves to a directory or has no `content` field.
- Added a skippable live test (`github-api.live.spec.ts`) that reads `contacts/$records/contact-jane-doe.json` from the real private repo `trakhimenok/ovdb-test-vault` (branch `poc/live-contact`) using `INGITDB_TEST_GITHUB_TOKEN=$(gh auth token)`. Skipped automatically when no token is set. Verified locally — passes against the live private repo.
- Full suite: **188 passed | 1 skipped** without a token; **188 passed** with `INGITDB_TEST_GITHUB_TOKEN` set.
- `tsc --noEmit` and `vite build` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV3pbooAc9UPpNdiaJuKve