### PR TITLE
feat(client-fs): implement read-only Node filesystem reader

### DIFF
--- a/packages/client-fs/src/__fixtures__/format-fixtures/.ingitdb/root-collections.yaml
+++ b/packages/client-fs/src/__fixtures__/format-fixtures/.ingitdb/root-collections.yaml
@@ -1,0 +1,1 @@
+spaces: spaces

--- a/packages/client-fs/src/__fixtures__/format-fixtures/spaces/.collection/definition.yaml
+++ b/packages/client-fs/src/__fixtures__/format-fixtures/spaces/.collection/definition.yaml
@@ -1,0 +1,10 @@
+record_file:
+    name: '{key}.yaml'
+    format: yaml
+    type: map[string]any
+columns:
+    name:
+        type: string
+        required: true
+columns_order:
+    - name

--- a/packages/client-fs/src/__fixtures__/format-fixtures/spaces/.collection/subcollections/contacts/definition.yaml
+++ b/packages/client-fs/src/__fixtures__/format-fixtures/spaces/.collection/subcollections/contacts/definition.yaml
@@ -1,0 +1,10 @@
+record_file:
+    name: '{key}.yaml'
+    format: yaml
+    type: map[string]any
+columns:
+    name:
+        type: string
+        required: true
+columns_order:
+    - name

--- a/packages/client-fs/src/__fixtures__/format-fixtures/spaces/family/contacts/$records/c1.yaml
+++ b/packages/client-fs/src/__fixtures__/format-fixtures/spaces/family/contacts/$records/c1.yaml
@@ -1,0 +1,1 @@
+name: Alice

--- a/packages/client-fs/src/__fixtures__/format-fixtures/spaces/work/contacts/$records/c1.yaml
+++ b/packages/client-fs/src/__fixtures__/format-fixtures/spaces/work/contacts/$records/c1.yaml
@@ -1,0 +1,1 @@
+name: Bob

--- a/packages/client-fs/src/client.spec.ts
+++ b/packages/client-fs/src/client.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { createFsIngitDbClient } from './client'
+
+// ---------------------------------------------------------------------------
+// FILESYSTEM READER + CROSS-LANGUAGE FORMAT CONTRACT
+//
+// These fixtures (src/__fixtures__/format-fixtures/) are a byte-identical copy of
+// the golden repo tree produced by the Go writer (github.com/ingitdb/dalgo2ingitdb),
+// documented in that repo's FORMAT.md and mirrored in @ingitdb/client-github. This
+// test drives the real @ingitdb/client-fs reader against that tree via node:fs, so
+// if the Go writer's on-disk format and this TS reader ever drift, one side's CI
+// goes red instead of a user's repo silently failing to load.
+// ---------------------------------------------------------------------------
+
+const fixturesRoot = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'format-fixtures')
+
+// The IngitDbClient signatures still carry (repo, branch); the fs reader ignores
+// them and reads from rootDir. Pass a placeholder repo for readability.
+const REPO = 'local/fixtures'
+
+describe('createFsIngitDbClient (read-only filesystem reader)', () => {
+  const client = () => createFsIngitDbClient({ rootDir: fixturesRoot })
+
+  it('resolves a top-level collection path & parses its schema from .collection/definition.yaml', async () => {
+    const { schema, collectionPath } = await client().loadCollectionSchema(REPO, undefined, 'spaces')
+    expect(collectionPath).toBe('spaces')
+    // The schema declares a required "name" string column (see FORMAT.md).
+    expect(schema.columnsMap['name']).toBeDefined()
+    expect(schema.columns_order).toContain('name')
+  })
+
+  it('loads the database config (collections) from .ingitdb/root-collections.yaml', async () => {
+    const config = await client().loadDatabaseConfig(REPO)
+    expect(config.collections).toEqual([{ id: 'spaces', path: 'spaces' }])
+  })
+
+  it('reads nested subcollection records scoped by parent (no cross-space collision)', async () => {
+    const c = client()
+    // Both nested collections address the same leaf collection + record id but live
+    // under different parent spaces — parent-scoped nesting must keep them distinct.
+    const familySchema = await c.loadCollectionSchema(REPO, undefined, 'spaces/family/contacts')
+    const workSchema = await c.loadCollectionSchema(REPO, undefined, 'spaces/work/contacts')
+
+    const family = await c.loadCollectionRecords(
+      REPO, undefined, 'spaces/family/contacts', familySchema.schema, familySchema.collectionPath
+    )
+    const work = await c.loadCollectionRecords(
+      REPO, undefined, 'spaces/work/contacts', workSchema.schema, workSchema.collectionPath
+    )
+
+    expect(family.records).toHaveLength(1)
+    expect(work.records).toHaveLength(1)
+    expect(family.records[0]).toMatchObject({ _id: 'c1', name: 'Alice' })
+    expect(work.records[0]).toMatchObject({ _id: 'c1', name: 'Bob' })
+    expect(family.records[0]._path).toBe('spaces/family/contacts/$records/c1.yaml')
+  })
+
+  it('resolves the subcollection schema from <top>/.collection/subcollections/<sub>/definition.yaml', async () => {
+    const { schema } = await client().loadCollectionSchema(REPO, undefined, 'spaces/family/contacts')
+    expect(schema.columnsMap['name']).toBeDefined()
+  })
+
+  it('loadRecord reads a single record file with _path metadata', async () => {
+    const rec = await client().loadRecord(REPO, 'spaces/work/contacts/$records/c1.yaml')
+    expect(rec.name).toBe('Bob')
+    expect(rec._path).toBe('spaces/work/contacts/$records/c1.yaml')
+  })
+
+  it('returns an empty record list for a non-existent collection', async () => {
+    const c = client()
+    const { schema, collectionPath } = await c.loadCollectionSchema(REPO, undefined, 'does/not/exist')
+    const { records } = await c.loadCollectionRecords(REPO, undefined, 'does/not/exist', schema, collectionPath)
+    expect(records).toEqual([])
+  })
+
+  it('reports read-only repo meta (no push permission)', async () => {
+    const meta = await client().loadRepoMeta(REPO)
+    expect(meta.permissions?.push).toBe(false)
+  })
+
+  it('loadFKViews returns the safe empty default', async () => {
+    const views = await client().loadFKViews(REPO, undefined, 'spaces', 'c1')
+    expect(views).toEqual([])
+  })
+
+  it('exposes an in-memory cache (get/set/delete/clear)', async () => {
+    const { cache } = client()
+    await cache.set('k', 42)
+    expect(await cache.get<number>('k')).toBe(42)
+    await cache.delete('k')
+    expect(await cache.get('k')).toBeNull()
+    await cache.set('k2', 'v')
+    await cache.clear()
+    expect(await cache.get('k2')).toBeNull()
+  })
+
+  it('createCommittedChangesStore is wired from @ingitdb/client', () => {
+    const store = client().createCommittedChangesStore()
+    expect(typeof store.add).toBe('function')
+  })
+
+  it('write path (createPendingChangesStore) is intentionally not implemented', () => {
+    expect(() => client().createPendingChangesStore()).toThrow(/not implemented/)
+  })
+})

--- a/packages/client-fs/src/client.ts
+++ b/packages/client-fs/src/client.ts
@@ -1,26 +1,374 @@
-import type { IngitDbClient, IngitDbClientOptions } from '@ingitdb/client'
-import { createCommittedChangesStore } from '@ingitdb/client'
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import type {
+  Cache,
+  CollectionEntry,
+  CollectionSchema,
+  DatabaseConfig,
+  FKView,
+  IngitDbClient,
+  IngitDbClientOptions,
+  PendingChangesStore,
+  RecordData,
+  RecordRow,
+  RepoMeta,
+  RepoSettings
+} from '@ingitdb/client'
+import {
+  buildCacheKey,
+  createCache,
+  createCommittedChangesStore,
+  parseCollectionSchema,
+  parseYaml
+} from '@ingitdb/client'
 
-const notImplemented = (name: string) => (): never => {
-  throw new Error(`@ingitdb/client-fs: ${name} is not yet implemented`)
+/**
+ * `@ingitdb/client-fs` is a **read-only** Node filesystem-backed reader for a
+ * checked-out inGitDB repository. It mirrors `@ingitdb/client-github` but reads
+ * collections/records from a local directory via `node:fs` instead of the
+ * GitHub API.
+ *
+ * Write operations (staging/committing changes) are intentionally left
+ * unimplemented — this client is a reader only. See `createPendingChangesStore`.
+ */
+export interface FsIngitDbClientOptions extends IngitDbClientOptions {
+  /** Absolute or relative path to the root of a checked-out inGitDB repo. */
+  rootDir?: string
+  /** Alias for {@link FsIngitDbClientOptions.rootDir}. */
+  dir?: string
 }
 
-export function createFsIngitDbClient(_options?: IngitDbClientOptions): IngitDbClient {
+/** The `IngitDbClient` facade returned by {@link createFsIngitDbClient}, plus the resolved root dir. */
+export interface FsIngitDbClient extends IngitDbClient {
+  /** The filesystem root the client reads from. */
+  rootDir: string
+}
+
+const SCHEMA_TTL = 5 * 60 * 1000
+const RECORDS_TTL = 5 * 60 * 1000
+const CONFIG_TTL = 2 * 60 * 1000
+const SHARED_LAYOUT_SEGMENT = '/.collections/'
+export const DEFAULT_MAX_RECORDS = 20
+
+const notImplemented = (name: string) => (): never => {
+  throw new Error(`@ingitdb/client-fs: ${name} is not implemented (client-fs is a read-only reader)`)
+}
+
+/** True when a readFile/readdir failure means "the path does not exist". */
+const isNotFound = (e: unknown): boolean =>
+  (e as NodeJS.ErrnoException)?.code === 'ENOENT' ||
+  (e as NodeJS.ErrnoException)?.code === 'ENOTDIR'
+
+const parseFileContent = (content: string, filePath: string): unknown => {
+  const ext = filePath.toLowerCase().split('.').pop()
+  if (ext === 'json') {
+    try { return JSON.parse(content) }
+    catch (e) { throw new Error(`Failed to parse JSON from ${filePath}: ${(e as Error).message}`) }
+  }
+  try { return parseYaml(content) || {} }
+  catch (e) { throw new Error(`Failed to parse YAML from ${filePath}: ${(e as Error).message}`) }
+}
+
+/**
+ * Resolves the data directory for a collection given its schema path and optional data_dir.
+ * Ported verbatim from `@ingitdb/client-github`.
+ */
+export const resolveDataPath = (schemaPath: string, dataDir?: string | null): string => {
+  const collectionsIdx = schemaPath.indexOf(SHARED_LAYOUT_SEGMENT)
+  if (collectionsIdx !== -1) {
+    const baseDir = schemaPath.slice(0, collectionsIdx)
+    if (!dataDir || dataDir === '.') return baseDir
+    return `${baseDir}/${dataDir}`
+  }
+  return schemaPath
+}
+
+export function createFsIngitDbClient(options?: FsIngitDbClientOptions): FsIngitDbClient {
+  const rootDir = options?.rootDir ?? options?.dir ?? process.cwd()
+  const cache: Cache = createCache() // in-memory Map cache (no browser persistence on Node)
+
+  /** Read a repo-relative POSIX path as UTF-8 text. `_sha` is not tracked on fs. */
+  const readText = async (relPath: string): Promise<{ decodedContent: string; sha?: string }> => {
+    const abs = join(rootDir, ...relPath.split('/'))
+    const decodedContent = await readFile(abs, 'utf8')
+    return { decodedContent }
+  }
+
+  /** List directory entries (files/dirs) for a repo-relative POSIX path. */
+  const listDir = async (relPath: string): Promise<{ name: string; isDir: boolean }[]> => {
+    const abs = join(rootDir, ...relPath.split('/'))
+    const dirents = await readdir(abs, { withFileTypes: true })
+    return dirents.map((d) => ({ name: d.name, isDir: d.isDirectory() }))
+  }
+
+  /**
+   * Resolve the physical collection path from a collectionId.
+   *
+   * - Top-level collections resolve through `.ingitdb/root-collections.yaml`.
+   * - Nested subcollection paths (a parent chain, e.g. `spaces/family/contacts`)
+   *   have no direct mapping entry, so they fall through and the collectionId is
+   *   returned unchanged — which IS the on-disk directory. This is what makes
+   *   parent-scoped nesting work: `spaces/family/contacts` and
+   *   `spaces/work/contacts` map to distinct directories and never collide.
+   */
+  const resolveCollectionPath = async (collectionId: string): Promise<string> => {
+    const cacheKey = buildCacheKey('root-collections', rootDir)
+    let mapping = await cache.get<Record<string, string>>(cacheKey)
+    if (!mapping) {
+      try {
+        const file = await readText('.ingitdb/root-collections.yaml')
+        mapping = (parseYaml(file.decodedContent) as Record<string, string>) || {}
+      } catch (e) {
+        if (!isNotFound(e)) console.warn('Failed to load root-collections mapping:', e)
+        mapping = {}
+      }
+      await cache.set(cacheKey, mapping, SCHEMA_TTL)
+    }
+    if (mapping[collectionId]) return mapping[collectionId]
+
+    // Namespace resolution: "ns.subId" -> "ns.*" entry -> nested root-collections.yaml
+    const dotIdx = collectionId.indexOf('.')
+    if (dotIdx !== -1) {
+      const namespace = collectionId.slice(0, dotIdx)
+      const subId = collectionId.slice(dotIdx + 1)
+      const nsKey = `${namespace}.*`
+      if (mapping[nsKey]) {
+        const basePath = mapping[nsKey]
+        try {
+          const subFile = await readText(`${basePath}/.ingitdb/root-collections.yaml`)
+          const subMapping = (parseYaml(subFile.decodedContent) as Record<string, string>) || {}
+          if (subMapping[subId]) return `${basePath}/${subMapping[subId]}`
+        } catch (e) {
+          if (!isNotFound(e)) console.warn(`[resolveCollectionPath] failed to resolve namespace ${namespace}:`, e)
+        }
+      }
+    }
+
+    // Nested parent-scoped path (or unknown id): the id IS the directory path.
+    return collectionId
+  }
+
+  /**
+   * Build candidate `definition.yaml` paths for a resolved collection path.
+   * Handles the dedicated layout, the shared `/.collections/` layout, and
+   * parent-scoped subcollections whose schema lives under the TOP collection at
+   * `<top>/.collection/subcollections/<sub>/definition.yaml`.
+   */
+  const schemaCandidates = (resolvedPath: string): string[] => {
+    const candidates = [
+      `${resolvedPath}/.collection/definition.yaml`,
+      `${resolvedPath}/definition.yaml`
+    ]
+    // Parent-scoped nesting: segments interleave collection/record/subcollection.
+    // e.g. "spaces/family/contacts" -> top "spaces", sub "contacts".
+    const segments = resolvedPath.split('/').filter(Boolean)
+    if (segments.length >= 3) {
+      const top = segments[0]
+      const sub = segments[segments.length - 1]
+      candidates.push(`${top}/.collection/subcollections/${sub}/definition.yaml`)
+    }
+    return candidates
+  }
+
+  const loadCollectionSchema = async (
+    _repo: string,
+    _branch: string | undefined,
+    collectionId: string,
+    skipCache = false
+  ): Promise<{ schema: CollectionSchema; schemaYaml: string; collectionPath: string }> => {
+    const cacheKey = buildCacheKey('col-schema', rootDir, collectionId)
+    if (!skipCache) {
+      const cached = await cache.get<{ schema: CollectionSchema; rawYaml: string; path: string }>(cacheKey)
+      if (cached) return { schema: cached.schema, schemaYaml: cached.rawYaml, collectionPath: cached.path }
+    }
+
+    const resolvedPath = await resolveCollectionPath(collectionId)
+
+    let file: { decodedContent: string } | null = null
+    for (const path of schemaCandidates(resolvedPath)) {
+      try { file = await readText(path); break }
+      catch (e) { if (!isNotFound(e)) throw e }
+    }
+
+    if (!file) {
+      const dataPath = resolveDataPath(resolvedPath)
+      const schema = parseCollectionSchema({})
+      await cache.set(cacheKey, { schema, rawYaml: '', path: dataPath }, SCHEMA_TTL)
+      return { schema, schemaYaml: '', collectionPath: dataPath }
+    }
+
+    const rawYaml = file.decodedContent
+    const parsed = parseCollectionSchema(rawYaml)
+    const dataPath = resolveDataPath(resolvedPath, parsed.data_dir as string | null | undefined)
+    await cache.set(cacheKey, { schema: parsed, rawYaml, path: dataPath }, SCHEMA_TTL)
+    return { schema: parsed, schemaYaml: rawYaml, collectionPath: dataPath }
+  }
+
+  const loadCollectionRecords = async (
+    _repo: string,
+    _branch: string | undefined,
+    collectionId: string,
+    schema: CollectionSchema,
+    collectionPath: string,
+    skipCache = false
+  ): Promise<{ records: RecordRow[]; ingrColumnTypes: Record<string, string> }> => {
+    const cacheKey = buildCacheKey('col-records', rootDir, collectionId)
+    if (!skipCache) {
+      const cached = await cache.get<{ records: RecordRow[] }>(cacheKey)
+      if (cached) return { records: cached.records, ingrColumnTypes: {} }
+    }
+
+    const sch = schema || ({} as CollectionSchema)
+    const colPath = collectionPath || sch.path || collectionId
+    const recordFilePattern = sch.record_file?.name || '{key}.yaml'
+    let loaded: RecordRow[] = []
+
+    // Single-file layout: record_file.name has no {key} placeholder.
+    if (!recordFilePattern.includes('{key}')) {
+      const filePath = `${colPath}/${recordFilePattern}`
+      try {
+        const file = await readText(filePath)
+        const data = parseFileContent(file.decodedContent, filePath)
+        if (Array.isArray(data)) {
+          loaded = (data as Record<string, unknown>[]).map((item, idx) => ({ _id: String(idx), _path: filePath, ...item }))
+        } else if (typeof data === 'object' && data !== null) {
+          loaded = Object.entries(data as Record<string, unknown>).map(([key, item]) => ({
+            _id: key, _path: filePath,
+            ...(typeof item === 'object' && item !== null ? (item as Record<string, unknown>) : {})
+          }))
+        }
+      } catch (e) {
+        if (!isNotFound(e)) throw e
+      }
+      await cache.set(cacheKey, { records: loaded }, RECORDS_TTL)
+      return { records: loaded, ingrColumnTypes: {} }
+    }
+
+    // File-per-record layout: records live under `<collectionPath>/$records/`.
+    const recordsBasePath = `${colPath}/$records`
+    let entries: { name: string; isDir: boolean }[]
+    try {
+      entries = await listDir(recordsBasePath)
+    } catch (e) {
+      if (isNotFound(e)) return { records: [], ingrColumnTypes: {} }
+      throw e
+    }
+
+    const fileExtRegex = /\.(yaml|yml|json)$/i
+    const files = entries
+      .filter((e) => !e.isDir && fileExtRegex.test(e.name) && !e.name.startsWith('.'))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, DEFAULT_MAX_RECORDS)
+
+    for (const entry of files) {
+      const relPath = `${recordsBasePath}/${entry.name}`
+      try {
+        const file = await readText(relPath)
+        const parsed = parseFileContent(file.decodedContent, relPath)
+        loaded.push({
+          _id: entry.name.replace(fileExtRegex, ''),
+          _path: relPath,
+          ...(parsed as Record<string, unknown>)
+        })
+      } catch (err) {
+        loaded.push({ _id: entry.name.replace(fileExtRegex, ''), _error: (err as Error).message })
+      }
+    }
+
+    await cache.set(cacheKey, { records: loaded }, RECORDS_TTL)
+    return { records: loaded, ingrColumnTypes: {} }
+  }
+
+  const loadRecord = async (
+    _repo: string,
+    recordPath: string,
+    _branch?: string
+  ): Promise<RecordData> => {
+    if (!recordPath) throw new Error('recordPath is required')
+    const file = await readText(recordPath)
+    const parsed = (parseYaml(file.decodedContent) as Record<string, unknown>) || {}
+    return { ...parsed, _path: recordPath, _sha: file.sha }
+  }
+
+  const loadDatabaseConfig = async (_repo: string, _branch?: string): Promise<DatabaseConfig> => {
+    const cacheKey = buildCacheKey('db-config', rootDir)
+    let rawYaml = ''
+    let parsed: Record<string, string> = {}
+    const cached = await cache.get<{ config: Record<string, string>; rawYaml: string }>(cacheKey)
+    if (cached) {
+      parsed = cached.config
+      rawYaml = cached.rawYaml
+    } else {
+      try {
+        const file = await readText('.ingitdb/root-collections.yaml')
+        rawYaml = file.decodedContent
+        parsed = (parseYaml(rawYaml) as Record<string, string>) || {}
+      } catch (e) {
+        if (!isNotFound(e)) throw e
+      }
+      await cache.set(cacheKey, { config: parsed, rawYaml }, CONFIG_TTL)
+    }
+
+    const collections: CollectionEntry[] = []
+    for (const [key, basePath] of Object.entries(parsed)) {
+      const nsMatch = /^(.+)\.\*$/.exec(key)
+      if (nsMatch) {
+        const namespace = nsMatch[1]
+        try {
+          const subFile = await readText(`${basePath}/.ingitdb/root-collections.yaml`)
+          const subParsed = (parseYaml(subFile.decodedContent) as Record<string, string>) || {}
+          for (const [subId, subPath] of Object.entries(subParsed)) {
+            collections.push({ id: `${namespace}.${subId}`, path: `${basePath}/${subPath}` })
+          }
+        } catch (e) {
+          if (!isNotFound(e)) console.warn(`[loadDatabaseConfig] failed to expand namespace ${namespace}:`, e)
+        }
+      } else {
+        collections.push({ id: key, path: basePath })
+      }
+    }
+
+    return { rawYaml, collections, views: [], triggers: [], subscribers: [] }
+  }
+
+  const loadRepoSettings = async (
+    _repo: string,
+    _branch?: string,
+    _skipCache?: boolean
+  ): Promise<RepoSettings> => {
+    try {
+      const file = await readText('.ingitdb/settings.yaml')
+      const parsed = parseYaml(file.decodedContent) as { languages?: RepoSettings['languages'] } | null
+      return { languages: Array.isArray(parsed?.languages) ? parsed!.languages : [] }
+    } catch (e) {
+      if (!isNotFound(e)) throw e
+      return { languages: [] }
+    }
+  }
+
+  // Read-only reader: report no push permission so consumers don't surface write
+  // affordances that would throw at `createPendingChangesStore`.
+  const loadRepoMeta = async (_repo: string): Promise<RepoMeta> => ({
+    permissions: { push: false }
+  })
+
+  // FK materialized views (`$ingitdb/<path>/$fk/`) are not emitted by the fs
+  // reader's fixtures; return the safe empty default, mirroring client-github's
+  // behaviour when no `$fk` directory exists.
+  const loadFKViews = async (): Promise<FKView[]> => []
+
   return {
-    cache: {
-      get: notImplemented('cache.get'),
-      set: notImplemented('cache.set'),
-      delete: notImplemented('cache.delete'),
-      clear: notImplemented('cache.clear')
-    },
-    loadDatabaseConfig: notImplemented('loadDatabaseConfig'),
-    loadCollectionSchema: notImplemented('loadCollectionSchema'),
-    loadCollectionRecords: notImplemented('loadCollectionRecords'),
-    loadRecord: notImplemented('loadRecord'),
-    loadRepoMeta: notImplemented('loadRepoMeta'),
-    loadRepoSettings: notImplemented('loadRepoSettings'),
-    loadFKViews: notImplemented('loadFKViews'),
-    createPendingChangesStore: notImplemented('createPendingChangesStore'),
+    rootDir,
+    cache,
+    loadDatabaseConfig,
+    loadCollectionSchema,
+    loadCollectionRecords,
+    loadRecord,
+    loadRepoMeta,
+    loadRepoSettings,
+    loadFKViews,
+    // Writing is out of scope for the read-only fs client.
+    createPendingChangesStore: notImplemented('createPendingChangesStore') as unknown as () => PendingChangesStore,
     createCommittedChangesStore: () => createCommittedChangesStore()
   }
 }

--- a/packages/client-fs/src/index.ts
+++ b/packages/client-fs/src/index.ts
@@ -1,1 +1,3 @@
-export { createFsIngitDbClient } from './client'
+export { createFsIngitDbClient, resolveDataPath } from './client'
+export type { FsIngitDbClient, FsIngitDbClientOptions } from './client'
+export type { IngitDbClientOptions } from '@ingitdb/client'

--- a/packages/client-fs/vite.config.ts
+++ b/packages/client-fs/vite.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
       formats: ['es', 'cjs']
     },
     rollupOptions: {
-      external: ['@ingitdb/client']
+      // Externalize the workspace client and all Node built-ins — this is a
+      // Node filesystem-backed package and must not bundle `node:*` modules.
+      external: [/^@ingitdb\/client$/, /^node:/]
     }
   },
   plugins: [dts({ insertTypesEntry: true })]

--- a/packages/client-github/src/__fixtures__/format-fixtures/.ingitdb/root-collections.yaml
+++ b/packages/client-github/src/__fixtures__/format-fixtures/.ingitdb/root-collections.yaml
@@ -1,0 +1,1 @@
+spaces: spaces

--- a/packages/client-github/src/__fixtures__/format-fixtures/spaces/.collection/definition.yaml
+++ b/packages/client-github/src/__fixtures__/format-fixtures/spaces/.collection/definition.yaml
@@ -1,0 +1,10 @@
+record_file:
+    name: '{key}.yaml'
+    format: yaml
+    type: map[string]any
+columns:
+    name:
+        type: string
+        required: true
+columns_order:
+    - name

--- a/packages/client-github/src/__fixtures__/format-fixtures/spaces/.collection/subcollections/contacts/definition.yaml
+++ b/packages/client-github/src/__fixtures__/format-fixtures/spaces/.collection/subcollections/contacts/definition.yaml
@@ -1,0 +1,10 @@
+record_file:
+    name: '{key}.yaml'
+    format: yaml
+    type: map[string]any
+columns:
+    name:
+        type: string
+        required: true
+columns_order:
+    - name

--- a/packages/client-github/src/__fixtures__/format-fixtures/spaces/family/contacts/$records/c1.yaml
+++ b/packages/client-github/src/__fixtures__/format-fixtures/spaces/family/contacts/$records/c1.yaml
@@ -1,0 +1,1 @@
+name: Alice

--- a/packages/client-github/src/__fixtures__/format-fixtures/spaces/work/contacts/$records/c1.yaml
+++ b/packages/client-github/src/__fixtures__/format-fixtures/spaces/work/contacts/$records/c1.yaml
@@ -1,0 +1,1 @@
+name: Bob

--- a/packages/client-github/src/format-contract.spec.ts
+++ b/packages/client-github/src/format-contract.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import type { GithubApi } from './github/github-api'
+import type { Cache } from '@ingitdb/client'
+
+// Mock idb so the module-level openDB() in idb-cache.ts doesn't blow up.
+vi.mock('idb', () => ({ openDB: () => Promise.resolve({}) }))
+const mockParseIngr = vi.hoisted(() => vi.fn())
+vi.mock('@ingr/codec', () => ({ parseIngr: mockParseIngr }))
+
+const { resolveCollectionPath, loadCollectionSchema } = await import('./collection/collection')
+const { loadRecord } = await import('./collection/record')
+
+// ---------------------------------------------------------------------------
+// CROSS-LANGUAGE FORMAT CONTRACT
+//
+// These fixtures (src/__fixtures__/format-fixtures/) are a byte-identical copy of
+// the golden repo tree produced by the Go writer (github.com/ingitdb/dalgo2ingitdb,
+// testdata/format-fixtures/), documented in that repo's FORMAT.md. This test drives
+// the real @ingitdb/client-github reader against that tree via a fixture-backed
+// GithubApi.getFileText, so if the Go writer's on-disk format and this TS reader
+// ever drift, one side's CI goes red instead of a user's repo silently failing to
+// load. If you intentionally change the format, update BOTH copies + FORMAT.md.
+// ---------------------------------------------------------------------------
+
+const fixturesRoot = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'format-fixtures')
+
+/** GithubApi whose getFileText serves files from the on-disk fixture tree. */
+function fixtureGithubApi(): GithubApi {
+  return {
+    getRateLimit: () => ({ limit: null, remaining: null, reset: null }),
+    getRepo: vi.fn(),
+    getBranches: vi.fn(),
+    getContents: vi.fn(),
+    getFileText: vi.fn(async (_repo: string, path: string) => {
+      const decodedContent = readFileSync(join(fixturesRoot, path), 'utf8')
+      return { decodedContent, sha: 'fixture-sha' }
+    }),
+    putFile: vi.fn(),
+    deleteFile: vi.fn(),
+    forkRepo: vi.fn(),
+    getBranchSHA: vi.fn(),
+    createBranch: vi.fn(),
+    checkExistingFork: vi.fn(),
+    waitForFork: vi.fn(),
+    syncForkBranch: vi.fn(),
+    getCommit: vi.fn(),
+    createTree: vi.fn(),
+    createCommit: vi.fn(),
+    updateBranchRef: vi.fn(),
+  } as GithubApi
+}
+
+function mockCache(): Cache {
+  const store = new Map<string, unknown>()
+  return {
+    async get<T>(key: string): Promise<T | null> { return (store.get(key) as T) ?? null },
+    async set<T>(key: string, value: T): Promise<T> { store.set(key, value); return value },
+    async delete(key: string) { store.delete(key) },
+    async clear() { store.clear() },
+  }
+}
+
+describe('on-disk format contract (Go writer <-> TS reader)', () => {
+  const repo = 'owner/repo'
+  const deps = () => ({ githubApi: fixtureGithubApi(), cache: mockCache() })
+
+  it('resolves a top-level collection path from .ingitdb/root-collections.yaml', async () => {
+    const path = await resolveCollectionPath(repo, undefined, 'spaces', deps())
+    expect(path).toBe('spaces')
+  })
+
+  it('parses a collection schema from .collection/definition.yaml', async () => {
+    const { schema, collectionPath } = await loadCollectionSchema(repo, undefined, 'spaces', deps())
+    expect(collectionPath).toBe('spaces')
+    // The schema declares a required "name" string column (see FORMAT.md).
+    expect(JSON.stringify(schema)).toContain('name')
+  })
+
+  it('reads nested subcollection records scoped by parent (no cross-space collision)', async () => {
+    // Two contacts share the leaf collection + record id but live under different
+    // parent spaces — the Option A nesting the Go writer produces.
+    const family = await loadRecord(
+      repo, 'spaces/family/contacts/$records/c1.yaml', undefined, { githubApi: fixtureGithubApi() },
+    )
+    const work = await loadRecord(
+      repo, 'spaces/work/contacts/$records/c1.yaml', undefined, { githubApi: fixtureGithubApi() },
+    )
+    expect(family.name).toBe('Alice')
+    expect(work.name).toBe('Bob')
+    expect(family._path).toBe('spaces/family/contacts/$records/c1.yaml')
+  })
+})


### PR DESCRIPTION
## Summary
Turns `packages/client-fs/src/client.ts` from a stub into a real **Node filesystem-backed, read-only** `IngitDbClient` reader. Given a local directory (a checked-out inGitDB repo), it reads collections/records from disk via `node:fs`, mirroring `@ingitdb/client-github` against the GitHub API.

## What's implemented
- `createFsIngitDbClient({ rootDir | dir })` — resolves the root dir at creation; `repo`/`branch` args in the `IngitDbClient` interface are accepted but ignored (drop-in shape).
- `loadCollectionSchema` — resolves path via `.ingitdb/root-collections.yaml`, reads `.collection/definition.yaml`, `parseCollectionSchema`. Also resolves nested subcollection schemas from `<top>/.collection/subcollections/<sub>/definition.yaml`.
- `loadCollectionRecords` — lists `$records/*.{yaml,yml,json}` and loads each; supports the single-file layout too.
- `loadRecord` — reads a file, `parseYaml`, returns `{...fields, _path, _sha?}`.
- `loadDatabaseConfig` / `loadRepoSettings` / `loadRepoMeta` — read from disk or sane defaults (repo meta reports `push: false` since the reader is read-only).
- `cache` — in-memory Map cache via `createCache()`.
- `createCommittedChangesStore` — reused from `@ingitdb/client`.

## Nested subcollections (key correctness point)
Parent-scoped records nest under the parent record directory: `spaces/family/contacts/$records/c1.yaml`. A nested collection is addressed by its parent chain (`spaces/family/contacts`); it has no `root-collections.yaml` entry, so `resolveCollectionPath` returns the id unchanged — which IS the on-disk directory. So `spaces/family/contacts` and `spaces/work/contacts` map to distinct dirs and same-id records never collide.

## Left unimplemented (by design)
- `createPendingChangesStore` — writing is out of scope; this client is a reader. It throws a descriptive error.

## Tests
`packages/client-fs/src/client.spec.ts` (11 tests) drives the real reader against a **byte-identical** copy of the golden format fixtures. Asserts top-level path/schema resolution and that `spaces/family/contacts` → `c1` = Alice while `spaces/work/contacts` → `c1` = Bob.

## Verification
- `pnpm --filter @ingitdb/client-fs test:run` → 11 passed
- Full workspace `pnpm test:run` → all green (client 33, client-github 190 +1 skipped, client-fs 11)
- `pnpm build` (turbo) → 3 successful; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV3pbooAc9UPpNdiaJuKve